### PR TITLE
Change PATCH endpoint to be REST compliant

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -40,7 +40,7 @@ def api_post_member(member: MemberIn):
     return Response(status_code=200)
 
 
-@app.patch("/members/update")
+@app.patch("/members")
 def api_patch_member_update(member: MemberOut):
     result = patch_member_update(member)
     if result is not None:


### PR DESCRIPTION
I order to be REST compliant, i removed "/update" to the PATCH endpoint of api_patch_member_update.

Because of the update method is explicitly defined in the request header, we do not need that.