### PR TITLE
Refacto du backend

### DIFF
--- a/app/lib/function.py
+++ b/app/lib/function.py
@@ -1,22 +1,20 @@
 from fastapi import UploadFile
 
 
-def verifIsPngAndJpeg(file: UploadFile):
-    signatures = {
-        "png": b"\x89\x50\x4E\x47\x0D\x0A\x1A\x0A",
-        "jpeg/jpg": b"\xFF\xD8\xFF\xE0",
-        "jpeg/exif": b"\xFF\xD8\xFF\xE1",
-        "jpeg/spiff": b"\xFF\xD8\xFF\xE8",
-        "jpeg/jfif": b"\xFF\xD8\xFF\xDB",
-        "jpeg/2000": b"\x00\x00\x00\x0C\x6A\x50\x20\x20\x0D\x0A\x87\x0A"
-    }
+def isInvalidImage(upload: UploadFile):
+    signatures = (
+        b"\x89\x50\x4E\x47\x0D\x0A\x1A\x0A",                # PNG
+        b"\xFF\xD8\xFF\xE0",                                # JPEG/JPG
+        b"\xFF\xD8\xFF\xE1",                                # JPEG/EXIF
+        b"\xFF\xD8\xFF\xE8",                                # JPEG/SPIFF
+        b"\xFF\xD8\xFF\xDB",                                # JPEG/JFIF
+        b"\x00\x00\x00\x0C\x6A\x50\x20\x20\x0D\x0A\x87\x0A" # JPEG/2000
+    )
 
-    header = file.file.read(12)
-    file.file.seek(0)
+    header = upload.file.read(12)
+    upload.file.close()
 
-    for file_type, signature in signatures.items():
-        if header.startswith(signature):
-            return file_type
-    file.file.close()
-    return None
+    return not any(
+        header.startswith(signature) for signature in signatures
+    )
 

--- a/app/lib/sql.py
+++ b/app/lib/sql.py
@@ -85,11 +85,8 @@ async def get_members_category(name_category: str) -> List[GetMembers]:
                                                                AND category.name = %s""", (name_category,)
         )
 
-        res = cursor.fetchall()
-        print(res)
-
         return [GetMembers(id=row.id, username=row.username, url_portfolio=row.url_portfolio)
-                for row in res if row.date_validate and not row.date_deleted]
+                for row in cursor.fetchall() if row.date_validate and not row.date_deleted]
 
 
 async def return_id_category_by_name(name: str) -> int:

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,8 @@
+from .routers import *
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from .routers import *
-from .routers import router_session
+
 
 app = FastAPI()
 
@@ -19,14 +20,10 @@ origins = [
 app.add_middleware(
     CORSMiddleware,
     allow_origins=origins,
-    allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
+    allow_credentials=True,
 )
 
-
-app.include_router(router_github.router)
-app.include_router(router_member.router)
-app.include_router(router_category.router)
-app.include_router(router_network.router)
-app.include_router(router_session.router)
+for router in routers:
+    app.include_router(router)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,6 +1,6 @@
-from .members import Member, MemberOut, MemberIn, GetMembers, MemberById
-from .categories import *
-from .member_has_category import MemberWithCategory, MemberHasCategoryIn, MemberHasCategory
-from .member_has_network import MemberHasNetwork, GetMemberHasNetwork, MemberHasNetworkIn
 from .network import Network
 from .session import Session, SessionCookie
+from .categories import Category, CategoryOut
+from .members import Member, MemberOut, MemberIn, GetMembers, MemberById
+from .member_has_network import MemberHasNetwork, GetMemberHasNetwork, MemberHasNetworkIn
+from .member_has_category import MemberWithCategory, MemberHasCategoryIn, MemberHasCategory, MemberHasCategoryOut

--- a/app/models/member_has_category.py
+++ b/app/models/member_has_category.py
@@ -1,5 +1,4 @@
 from typing import List
-
 from pydantic import BaseModel
 
 

--- a/app/models/member_has_network.py
+++ b/app/models/member_has_network.py
@@ -1,5 +1,4 @@
 from typing import List
-
 from pydantic import BaseModel
 
 

--- a/app/models/members.py
+++ b/app/models/members.py
@@ -1,7 +1,6 @@
 from typing import Optional
-
-from pydantic import BaseModel
 from datetime import datetime
+from pydantic import BaseModel
 
 
 class MemberById(BaseModel):

--- a/app/models/session.py
+++ b/app/models/session.py
@@ -3,11 +3,11 @@ from datetime import datetime
 
 
 class SessionCookie(BaseModel):
-    access_token = str
-    id_member = int
-    refresh_token = str
+    access_token: str
+    id_member: int
+    refresh_token: str
 
 
 class Session(SessionCookie):
-    date_created = datetime
+    date_created: datetime
 

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -2,3 +2,12 @@ from .router_github import *
 from .router_member import *
 from .router_category import *
 from .router_network import *
+from .router_session import *
+
+routers = (
+    router_github.router,
+    router_member.router,
+    router_category.router,
+    router_network.router,
+    router_session.router
+)

--- a/app/routers/router_category.py
+++ b/app/routers/router_category.py
@@ -1,10 +1,10 @@
-from typing import List
+from app.models import *
+from app.lib.sql import *
 
+from typing import List
 from fastapi import APIRouter
 from starlette.responses import Response
 
-from app.lib.sql import *
-from app.models import *
 
 router = APIRouter(
     prefix="/category",
@@ -19,7 +19,4 @@ async def api_get_categories():
 
 @router.post("/")
 async def api_post_category(category: CategoryOut):
-    result = await post_category(category)
-    if result is not None:
-        return Response(status_code=400)
-    return Response(status_code=201)
+    return Response(status_code = await post_category(category))

--- a/app/routers/router_github.py
+++ b/app/routers/router_github.py
@@ -1,65 +1,68 @@
+import jwt
 import secrets
 
-import jwt
-from fastapi import APIRouter, Response
-from starlette.responses import RedirectResponse
-
-from fastapi_sso.sso.github import GithubSSO
+from app import settings
 from app.lib.sql import *
-from starlette.requests import Request
-
-from app.settings import GITHUB
 
 from datetime import datetime, timedelta
+from fastapi import APIRouter, Response
+from fastapi_sso.sso.github import GithubSSO
+from starlette.requests import Request
+from starlette.responses import RedirectResponse
 
-from app import settings
 
 router = APIRouter(
     prefix="/github",
     tags=["github"]
 )
 
-SECRET_KEY = settings.SECRET_KEY
-
-github_sso = GithubSSO(GITHUB["client_id"], GITHUB["client_secret"], f"{GITHUB['callback_uri']}/github/callback")
+github_sso = GithubSSO(
+    settings.GITHUB["client_id"],
+    settings.GITHUB["client_secret"],
+    f"{settings.GITHUB['callback_uri']}/github/callback"
+)
 
 
 @router.get("/login")
 async def github_login():
-    """Generate login url and redirect"""
     return await github_sso.get_login_redirect()
 
 
 @router.get("/callback")
 async def github_callback(request: Request) -> Response:
-    """Process login response from Google and return user info"""
     user = await github_sso.verify_and_process(request)
     member = await get_member_by_username(user.display_name)
-    if member is None:
-        member_id = await register_new_member(user.display_name)
-    else:
-        member_id = member.id
+
+    member_id = member.id if member else await register_new_member(user.display_name)
+    if not member_id:
+        return Response(status_code=500)
+
     access_token = secrets.token_hex(16)
     refresh_token = secrets.token_hex(16)
+
     session = await get_session(member_id)
     token_data = {"user_id": member_id, "access_token": access_token, "refresh_token": refresh_token}
-    #verifiez si une session n'existe pas
-    if session is not None:
-        temps_date = timedelta(minutes=60)
-        if session.date_created + temps_date > datetime.now():
-            token_data = {"user_id": session.id_member, "access_token": session.access_token, "refresh_token": session.refresh_token}
-        else:
-            await delete_session(member_id)
-            await register_token(access_token, refresh_token, member_id)
-    else:
+
+    if not session:
         await register_token(access_token, refresh_token, member_id)
+    elif session.date_created + timedelta(minutes=60) > datetime.now():
+        token_data = {"user_id": session.id_member, "access_token": session.access_token, "refresh_token": session.refresh_token}
+    else:
+        await delete_session(member_id)
+        await register_token(access_token, refresh_token, member_id)
+
     print(token_data)
-    token = jwt.encode(token_data, SECRET_KEY, algorithm=settings.ALGORITHM)
-    token_bis = {"id_member": member_id}
-    # Redirigez l'utilisateur vers la page de profil
-    url_response = f"http://127.0.0.1:5173/profil/{member_id}"
-    response = RedirectResponse(url=url_response)
-    # Créez un cookie HTTP avec le token
-    response.set_cookie(key="access_token", value=token, httponly=True)
-    response.set_cookie(key="token_user", value=token_bis, httponly=False)
+    response = RedirectResponse(url=f"http://127.0.0.1:5173/profil/{member_id}")
+    
+    response.set_cookie(
+        key="token_user",
+        value={"id_member": member_id},
+        httponly=False
+    )
+    response.set_cookie(
+        key="access_token",
+        value=jwt.encode(token_data, settings.SECRET_KEY, algorithm=settings.ALGORITHM),
+        httponly=True
+    )
+
     return response

--- a/app/routers/router_member.py
+++ b/app/routers/router_member.py
@@ -1,12 +1,11 @@
-from typing import List
+from app.models import *
+from app.lib.sql import *
+from app.lib.function import isInvalidImage
 
+from typing import List
 from fastapi import APIRouter
 from starlette.responses import Response
 
-from app.lib.function import verifIsPngAndJpeg
-from app.lib.sql import *
-from app.models import *
-from app.models.member_has_category import MemberHasCategoryOut
 
 router = APIRouter(
     prefix="/member",
@@ -21,32 +20,23 @@ async def api_get_members():
 
 @router.get("/{id:int}", response_model=MemberIn)
 async def api_get_member_by_id(id: int):
-    member = await get_member_by_id(id)
-    if member is None:
-        return Response(status_code=404)
-    return member
+    return await get_member_by_id(id) or Response(status_code=404)
 
 
 @router.patch("/")
 async def api_patch_member_update(member: MemberOut):
-    result = await patch_member_update(member)
-    if result is not None:
-        return Response(status_code=400)
-    return Response(status_code=201)
+    return Response(status_code = await patch_member_update(member))
 
 
 @router.patch("/image_portfolio")
 async def api_add_image_portfolio(file: UploadFile, id_member: int):
     if file.size > 200 * 10000:
         return Response(status_code=413)
-    if file.content_type not in ['image/jpeg', 'image/png']:
+    
+    if file.content_type not in ('image/jpeg', 'image/png') or isInvalidImage(file):
         return Response(status_code=415)
-    if verifIsPngAndJpeg(file) is None:
-        return Response(status_code=415)
-    verif = await add_image_portfolio(file, id_member)
-    if verif is not None:
-        return Response(status_code=500)
-    return Response(status_code=200)
+    
+    return Response(status_code = await add_image_portfolio(file, id_member))
 
 
 @router.get("/image_portfolio_by_id")
@@ -56,10 +46,7 @@ async def api_get_image_portfolio_by_id_member(id_member: int):
 
 @router.post("/category")
 async def api_post_add_category_on_member(member: MemberHasCategory):
-    category = await post_add_category_on_member(member)
-    if category is not None:
-        return Response(status_code=400)
-    return Response(status_code=201)
+    return Response(status_code = await post_add_category_on_member(member))
 
 
 @router.get("/list_category/{id:int}", response_model=List[CategoryOut])
@@ -74,18 +61,12 @@ async def api_get_member_has_category_by_id_member(id: int):
 
 @router.delete("/category")
 async def api_delete_category_delete_by_member(member: MemberHasCategory):
-    verif = await delete_category_delete_by_member(member)
-    if verif is not None:
-        return Response(status_code=400)
-    return Response(status_code=200)
+    return Response(status_code = await delete_category_delete_by_member(member))
 
 
 @router.get("/category={name:str}")
 async def api_get_members_category(name: str):
-    member = await get_members_category(name)
-    if member is None:
-        return Response(status_code=404)
-    return member
+    return await get_members_category(name) or Response(status_code=404)
 
 
 @router.get("/network/{id:int}", response_model=List[GetMemberHasNetwork])
@@ -95,16 +76,10 @@ async def api_get_network_of_member(id: int):
 
 @router.post("/network")
 async def api_post_network_on_member(member: MemberHasNetwork):
-    networks = await post_network_on_member(member)
-    if networks is not None:
-        return Response(status_code=400)
-    return Response(status_code=201)
+    return Response(status_code = await post_network_on_member(member))
 
 
 @router.delete("/network")
 async def api_delete_network_delete_by_member(member: MemberHasNetworkIn):
-    verif = await delete_network_delete_by_member(member)
-    if verif is not None:
-        return Response(status_code=400)
-    return Response(status_code=200)
+    return Response(status_code = await delete_network_delete_by_member(member))
 

--- a/app/routers/router_network.py
+++ b/app/routers/router_network.py
@@ -1,7 +1,8 @@
-from fastapi import APIRouter, Response
-
 from app.lib.sql import *
+
 from typing import List
+from fastapi import APIRouter
+
 
 router = APIRouter(
     prefix="/network",

--- a/app/routers/router_session.py
+++ b/app/routers/router_session.py
@@ -1,16 +1,10 @@
-from __future__ import annotations
-
-from typing import Optional, Union, Annotated
-
 import jwt
-from fastapi import APIRouter, Cookie, Header
+from fastapi import APIRouter
 from starlette.requests import Request
 
 from app.lib.sql import verif_session
-from starlette.responses import Response
-
-from app.models.session import SessionCookie
 from app.settings import SECRET_KEY, ALGORITHM
+
 
 router = APIRouter(
     prefix="/session",
@@ -23,11 +17,9 @@ async def api_is_connected(request: Request):
     try:
         access_token = request.cookies.get('access_token')
         cookie_session_decode = jwt.decode(access_token, SECRET_KEY, ALGORITHM)
+
         print(cookie_session_decode)
-        if await verif_session(cookie_session_decode):
-            return {"status": 200}
-        else:
-            return {"status": 401}
+        return {"status": await verif_session(cookie_session_decode)}
     except Exception as e:
         print(e)
         return {"status": 400}

--- a/app/settings.py
+++ b/app/settings.py
@@ -1,15 +1,18 @@
-import os
+from os import environ
+from dotenv import load_dotenv
 
-USER = os.environ.get("MYSQL_USER")
-PASSWORD = os.environ.get("MYSQL_PASSWORD")
-HOST = os.environ.get("MYSQL_HOST", default="localhost")
-DATABASE = os.environ.get("MYSQL_DATABASE")
-PORT = os.environ.get("MYSQL_PORT", default=3306)
-ALGORITHM = os.environ.get("ALGORITHM")
-SECRET_KEY = os.environ.get("SECRET_KEY")
+load_dotenv()
+
+USER       = environ.get("MYSQL_USER")
+PASSWORD   = environ.get("MYSQL_PASSWORD")
+HOST       = environ.get("MYSQL_HOST", default="localhost")
+DATABASE   = environ.get("MYSQL_DATABASE")
+PORT       = environ.get("MYSQL_PORT", default=3306)
+ALGORITHM  = environ.get("ALGORITHM")
+SECRET_KEY = environ.get("SECRET_KEY")
 
 GITHUB = {
-    "client_id": os.environ.get("GITHUB_CLIENT_ID"),
-    "client_secret": os.environ.get("GITHUB_CLIENT_SECRET"),
-    "callback_uri": os.environ.get("GITHUB_CALLBACK_URI")
+    "client_id":     environ.get("GITHUB_CLIENT_ID"),
+    "client_secret": environ.get("GITHUB_CLIENT_SECRET"),
+    "callback_uri":  environ.get("GITHUB_CALLBACK_URI")
 }


### PR DESCRIPTION
- Remplacement de `cursor = mydb.cursor()` par `with mydb.cursor() as cursor` pour assurer la fermeture du curseur
- Utilisation de `named_tuple=True` avec les curseurs pour ne pas avoir à créer les `named_tuple` manuellement
- Simplification des conditions (ex. `x is None` → `not x`)
- Les fonctions SQL renvoient directement un code HTTP pour simplifier les routes :
   ```py
   @router.post("/")
   async def api_post_category(category: CategoryOut):
       return Response(status_code = await post_category(category))
    ```
- Code 500 si la création d'un utilisateur râte (router Github)
- Suppression des variables temporaires à usage unique
- Chargement du fichier `.env` dans `settings.py`
- Liste `routers` dans `/app/routers/__init__.py` pour inclure chaque router avec une for loop dans le main

> [!Warning]
> Je n'ai testé que certaines routes sans passer par le front. Dans l'idéal, il faudrait tester avec de vraies données et avec le serveur front avant de merge.